### PR TITLE
Cache max-age or expires

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@
 
 ## Caching
 
-*   Add some more points here...
+*   The cache must have a  max age or expires. The reason why is, so that the site will be updated for people who have saved the cookie. They can see the updates if the cookies are renewed. 
 
 ## Minification
 


### PR DESCRIPTION
The cache must have a  max age or expires. The reason why is, so that
the site will be updated for people who have saved the cookie. They can
see the updates if the cookies are renewed.

bron: https://www.html5rocks.com/en/tutorials/speed/img-compression/