### PR TITLE
Image-size is to big

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,8 @@
 
 ### Images
 
-*   When you compress the images you can save up to 548.3 kb in size. The reason why we'd do this, is to make the website a lot faster! On slow 3G the main image takes up to 15 seconds to load!
+*   Add some more points here...
+*   Compress images
 
 ### CSS
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@
 
 ### Images
 
-*   Add some more points here...
+*   When you compress the images you can save up to 548.3 kb in size. The reason why we'd do this, is to make the website a lot faster! On slow 3G the main image takes up to 15 seconds to load!
 
 ### CSS
 


### PR DESCRIPTION
When you compress the images you can save up to 548.3 kb in size. The reason why we'd do this, is to make the website a lot faster! On slow 3G the main image takes up to 15 seconds to load!

https://www.quora.com/Why-is-image-compression-important