### PR TITLE
Format png instead of jpg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@
 ### Images
 
 *   Compress images
+*   Images with little detail and small colour pallet, are smaller with png format instead of jpg. If possible, use svg.
 
 ### CSS
 


### PR DESCRIPTION
Pick the right image format.  Supporting source.
https://support.blurb.com/hc/en-us/articles/207795196-When-to-use-PNG-vs
-JPG-images

This image would be smaller with png: (If converted from raw format)
https://i.vimeocdn.com/portrait/21157600_120x120.jpg